### PR TITLE
Allow setting of countryCode externally.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ class Tidal {
     // some base params for GET requests
     this.params = `limit=10000&countryCode=${this.countryCode}`;
     // params for Tidal pages that require a locale and device type
-    this.localeParams = 'locale=en_US&deviceType=BROWSER&countryCode=US';
+    this.localeParams = `locale=en_US&deviceType=BROWSER&countryCode=${this.countryCode}`;
   }
 
   /**


### PR DESCRIPTION
By using the countryCode var in both strings, setting the country code externally will work.
E.g.
`var tidal = new Tidal();
tidal.countryCode = "DK";`