### PR TITLE
#12 changes tidal webToken to a new working one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@andreeckardt/tidal-api-wrapper",
+  "name": "@korve/tidal-api-wrapper",
   "version": "1.8.0",
   "description": "An unofficial API wrapper for Tidal Music",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tidal-api-wrapper",
-  "version": "1.7.1",
+  "name": "@andreeckardt/tidal-api-wrapper",
+  "version": "1.8.0",
   "description": "An unofficial API wrapper for Tidal Music",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class Tidal {
    */
   constructor(options = {}) {
     this.url = 'https://api.tidal.com/v1';
-    this.webToken = 'kgsOOmYk3zShYrNP';
+    this.webToken = 'gsFXkJqGrUNoYMQPZe4k3WKwijnrp8iGSwn3bApe';
     this.countryCode = options.countryCode || 'US';
     this.limit = options.limit || 1000;
     this.api = axios.create({


### PR DESCRIPTION
This changes the webToken to the new one used by tidal web player. The wrapper should work again.

closes #12